### PR TITLE
Jfrog Anno Mojo maven plugin do not work with jdk8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,18 +55,6 @@
         <developerConnection>scm:git:github.com:jcabi/jcabi-beanstalk-maven-plugin.git</developerConnection>
         <url>https://github.com/jcabi/jcabi-beanstalk-maven-plugin</url>
     </scm>
-    <repositories>
-        <repository>
-            <id>repo.jfrog.org</id>
-            <url>http://repo.jfrog.org/artifactory/plugins-releases</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jfrog.org</id>
-            <url>http://repo.jfrog.org/artifactory/plugins-releases</url>
-        </pluginRepository>
-    </pluginRepositories>
     <properties>
         <maven.version>3.0.5</maven.version>
         <sisu.version>2.3.4</sisu.version>
@@ -95,12 +83,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-        </dependency>
-        <dependency>
-            <!-- see http://wiki.jfrog.org/confluence/display/OSS/Maven+Anno+Mojo -->
-            <groupId>org.jfrog.maven.annomojo</groupId>
-            <artifactId>maven-plugin-anno</artifactId>
-            <version>1.4.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -212,14 +194,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.jfrog.maven.annomojo</groupId>
-                        <artifactId>maven-plugin-tools-anno</artifactId>
-                        <version>1.4.1</version>
-                        <scope>runtime</scope>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/jcabi/beanstalk/maven/plugin/AbstractBeanstalkMojo.java
+++ b/src/main/java/com/jcabi/beanstalk/maven/plugin/AbstractBeanstalkMojo.java
@@ -51,7 +51,6 @@ import java.util.zip.ZipFile;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.settings.Settings;
-import org.jfrog.maven.annomojo.annotations.MojoParameter;
 import org.slf4j.impl.StaticLoggerBinder;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.error.YAMLException;
@@ -68,80 +67,57 @@ import org.yaml.snakeyaml.error.YAMLException;
 abstract class AbstractBeanstalkMojo extends AbstractMojo {
     /**
      * Setting.xml.
+     * @parameter name="settings" default-value="${settings}"
+     * @readonly
+     * @required
      */
-    @MojoParameter(
-        expression = "${settings}",
-        required = true,
-        readonly = true,
-        description = "Maven settings.xml reference"
-    )
     private transient Settings settings;
 
     /**
      * Shall we skip execution?
+     * @parameter name="skip" default-value="false"
      */
-    @MojoParameter(
-        defaultValue = "false",
-        required = false,
-        description = "Skips execution"
-    )
     private transient boolean skip;
 
     /**
      * Server ID to deploy to.
+     * @parameter name="server" default-value="aws.amazon.com"
      */
-    @MojoParameter(
-        defaultValue = "aws.amazon.com",
-        required = false,
-        description = "ID of the server to deploy to, from settings.xml"
-    )
     private transient String server;
 
     /**
      * Application name (also the name of environment and CNAME).
+     * @parameter name="name"
+     * @required
      */
-    @MojoParameter(
-        required = true,
-        description = "EBT application name, environment name, and CNAME"
-    )
     private transient String name;
 
     /**
      * S3 bucket.
+     * @parameter name="bucket"
+     * @required
      */
-    @MojoParameter(
-        required = true,
-        description = "Amazon S3 bucket name where to upload WAR file"
-    )
     private transient String bucket;
 
     /**
      * S3 key name.
+     * @parameter name="key"
+     * @required
      */
-    @MojoParameter(
-        required = true,
-        description = "Amazon S3 bucket key where to upload WAR file"
-    )
     private transient String key;
 
     /**
      * Template name.
+     * @parameter name="template"
+     * @required
      */
-    @MojoParameter(
-        required = true,
-        description = "Amazon Elastic Beanstalk configuration template name"
-    )
     private transient String template;
 
     /**
      * WAR file to deploy.
-     * @checkstyle LineLength (3 lines)
+     * @checkstyle LineLength (1 line)
+     * @parameter name="war" defaultValue = "${project.build.directory}/${project.build.finalName}.war"
      */
-    @MojoParameter(
-        defaultValue = "${project.build.directory}/${project.build.finalName}.war",
-        required = false,
-        description = "Location of .WAR file to deploy"
-    )
     private transient File war;
 
     /**

--- a/src/main/java/com/jcabi/beanstalk/maven/plugin/AbstractBeanstalkMojo.java
+++ b/src/main/java/com/jcabi/beanstalk/maven/plugin/AbstractBeanstalkMojo.java
@@ -116,7 +116,7 @@ abstract class AbstractBeanstalkMojo extends AbstractMojo {
     /**
      * WAR file to deploy.
      * @checkstyle LineLength (1 line)
-     * @parameter name="war" defaultValue = "${project.build.directory}/${project.build.finalName}.war"
+     * @parameter name="war" default-value="${project.build.directory}/${project.build.finalName}.war"
      */
     private transient File war;
 

--- a/src/main/java/com/jcabi/beanstalk/maven/plugin/DeployMojo.java
+++ b/src/main/java/com/jcabi/beanstalk/maven/plugin/DeployMojo.java
@@ -32,8 +32,6 @@ package com.jcabi.beanstalk.maven.plugin;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.log.Logger;
 import javax.validation.constraints.NotNull;
-import org.jfrog.maven.annomojo.annotations.MojoGoal;
-import org.jfrog.maven.annomojo.annotations.MojoPhase;
 
 /**
  * Deploys WAR artifact to AWS Elastic Beanstalk.
@@ -41,9 +39,9 @@ import org.jfrog.maven.annomojo.annotations.MojoPhase;
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 0.3
+ * @goal deploy
+ * @phase deploy
  */
-@MojoGoal("deploy")
-@MojoPhase("deploy")
 @Loggable(Loggable.INFO)
 public final class DeployMojo extends AbstractBeanstalkMojo {
 

--- a/src/main/java/com/jcabi/beanstalk/maven/plugin/UpdateMojo.java
+++ b/src/main/java/com/jcabi/beanstalk/maven/plugin/UpdateMojo.java
@@ -32,8 +32,6 @@ package com.jcabi.beanstalk.maven.plugin;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.log.Logger;
 import javax.validation.constraints.NotNull;
-import org.jfrog.maven.annomojo.annotations.MojoGoal;
-import org.jfrog.maven.annomojo.annotations.MojoPhase;
 
 /**
  * Update WAR artifact in AWS Elastic Beanstalk to a new version.
@@ -41,9 +39,9 @@ import org.jfrog.maven.annomojo.annotations.MojoPhase;
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 0.7.1
+ * @goal update
+ * @phase deploy
  */
-@MojoGoal("update")
-@MojoPhase("deploy")
 @Loggable(Loggable.INFO)
 public final class UpdateMojo extends AbstractBeanstalkMojo {
 


### PR DESCRIPTION
Removed Jfrog Anno Mojo maven plugin and annotations replaced with javadoc attributes.
Solving https://github.com/jcabi/jcabi-beanstalk-maven-plugin/issues/27