### PR TITLE
Update URL for Javadoc badge's image

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PDD status](http://www.0pdd.com/svg?name=jcabi/jcabi-beanstalk-maven-plugin)](http://www.0pdd.com/p?name=jcabi/jcabi-beanstalk-maven-plugin)
 [![Build status](https://ci.appveyor.com/api/projects/status/rudkdp50i862rhbh/branch/master?svg=true)](https://ci.appveyor.com/project/yegor256/jcabi-beanstalk-maven-plugin/branch/master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.jcabi/jcabi-beanstalk-maven-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.jcabi/jcabi-beanstalk-maven-plugin)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.jcabi/jcabi-beanstalk-maven-plugin/badge.svg)](http://www.javadoc.io/doc/com.jcabi/jcabi-beanstalk-maven-plugin)
+[![Javadoc](https://javadoc.io/badge/com.jcabi/jcabi-beanstalk-maven-plugin.svg)](http://www.javadoc.io/doc/com.jcabi/jcabi-beanstalk-maven-plugin)
 
 More details are here:
 [beanstalk.jcabi.com](http://beanstalk.jcabi.com/index.html)


### PR DESCRIPTION
OpenShit Online V2 is closed and this domain is not accessible anymore.
And javadoc.io introduce badges hosted directly on javadoc.io