### PR TITLE
Fix #17: maven-plugin-plugin fails under Java8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.iml
 node_modules/
 target/
+ajcore.*.txt

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.jcabi</groupId>
         <artifactId>jcabi</artifactId>
-        <version>1.18</version>
+        <version>1.44.0</version>
     </parent>
     <artifactId>jcabi-beanstalk-maven-plugin</artifactId>
     <version>1.0-SNAPSHOT</version>
@@ -33,6 +33,8 @@
     <properties>
         <maven.version>3.0.5</maven.version>
         <sisu.version>2.3.4</sisu.version>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
     </properties>
     <distributionManagement>
         <site>
@@ -58,6 +60,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>1.18.30</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -121,11 +124,44 @@
             <artifactId>snakeyaml</artifactId>
             <version>1.31</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.13.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>6.2.5.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>2.2.6</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
                 <executions>
                     <execution>
                         <id>default-compile</id>
@@ -157,6 +193,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.13.1</version>
                 <executions>
                     <execution>
                         <id>generated-helpmojo</id>

--- a/src/main/java/com/jcabi/beanstalk/maven/plugin/AbstractBeanstalkMojo.java
+++ b/src/main/java/com/jcabi/beanstalk/maven/plugin/AbstractBeanstalkMojo.java
@@ -24,6 +24,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.settings.Settings;
 import org.slf4j.impl.StaticLoggerBinder;
 import org.yaml.snakeyaml.Yaml;
@@ -41,57 +42,52 @@ import org.yaml.snakeyaml.error.YAMLException;
 abstract class AbstractBeanstalkMojo extends AbstractMojo {
     /**
      * Setting.xml.
-     * @parameter name="settings" default-value="${settings}"
-     * @readonly
-     * @required
      */
+    @Parameter(defaultValue = "${settings}", readonly = true, required = true)
     private transient Settings settings;
 
     /**
      * Shall we skip execution?
-     * @parameter name="skip" default-value="false"
      */
+    @Parameter(defaultValue = "false")
     private transient boolean skip;
 
     /**
      * Server ID to deploy to.
-     * @parameter name="server" default-value="aws.amazon.com"
      */
+    @Parameter(defaultValue = "aws.amazon.com")
     private transient String server;
 
     /**
      * Application name (also the name of environment and CNAME).
-     * @parameter name="name"
-     * @required
      */
+    @Parameter(required = true)
     private transient String name;
 
     /**
      * S3 bucket.
-     * @parameter name="bucket"
-     * @required
      */
+    @Parameter(required = true)
     private transient String bucket;
 
     /**
      * S3 key name.
-     * @parameter name="key"
-     * @required
      */
+    @Parameter(required = true)
     private transient String key;
 
     /**
      * Template name.
-     * @parameter name="template"
-     * @required
      */
+    @Parameter(required = true)
     private transient String template;
 
     /**
      * WAR file to deploy.
-     * @checkstyle LineLength (1 line)
-     * @parameter name="war" default-value="${project.build.directory}/${project.build.finalName}.war"
      */
+    @Parameter(
+        defaultValue = "${project.build.directory}/${project.build.finalName}.war"
+    )
     private transient File war;
 
     /**

--- a/src/main/java/com/jcabi/beanstalk/maven/plugin/AbstractBeanstalkMojo.java
+++ b/src/main/java/com/jcabi/beanstalk/maven/plugin/AbstractBeanstalkMojo.java
@@ -14,7 +14,6 @@ import com.amazonaws.util.json.JSONObject;
 import com.google.common.base.Joiner;
 import com.google.common.io.CharStreams;
 import com.google.common.io.Closeables;
-import com.jcabi.aspects.Tv;
 import com.jcabi.log.Logger;
 import java.io.File;
 import java.io.IOException;
@@ -245,7 +244,7 @@ abstract class AbstractBeanstalkMojo extends AbstractMojo {
         final long start = System.currentTimeMillis();
         while (!green) {
             final long age = System.currentTimeMillis() - start;
-            if (age > TimeUnit.MINUTES.toMillis(Tv.FIFTEEN)) {
+            if (age > TimeUnit.MINUTES.toMillis(15L)) {
                 Logger.warn(this, "Waiting for %[ms]s, time to give up", age);
                 break;
             }
@@ -254,7 +253,7 @@ abstract class AbstractBeanstalkMojo extends AbstractMojo {
                 "%s is not GREEN yet, let's wait another 15 second...", env
             );
             try {
-                TimeUnit.SECONDS.sleep(Tv.FIFTEEN);
+                TimeUnit.SECONDS.sleep(15L);
             } catch (final InterruptedException ex) {
                 Thread.currentThread().interrupt();
                 throw new DeploymentException(ex);

--- a/src/main/java/com/jcabi/beanstalk/maven/plugin/Application.java
+++ b/src/main/java/com/jcabi/beanstalk/maven/plugin/Application.java
@@ -13,7 +13,6 @@ import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsResult;
 import com.amazonaws.services.elasticbeanstalk.model.EnvironmentDescription;
 import com.amazonaws.services.elasticbeanstalk.model.SwapEnvironmentCNAMEsRequest;
 import com.jcabi.aspects.Loggable;
-import com.jcabi.aspects.Tv;
 import com.jcabi.log.Logger;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -301,7 +300,7 @@ final class Application {
         return String.format(
             "%s-e%03d",
             this.name,
-            Tv.HUNDRED + new Random().nextInt(Tv.NINE * Tv.HUNDRED)
+            100 + new Random().nextInt(900)
         );
     }
 

--- a/src/main/java/com/jcabi/beanstalk/maven/plugin/DeployMojo.java
+++ b/src/main/java/com/jcabi/beanstalk/maven/plugin/DeployMojo.java
@@ -7,6 +7,8 @@ package com.jcabi.beanstalk.maven.plugin;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.log.Logger;
 import javax.validation.constraints.NotNull;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 
 /**
  * Deploys WAR artifact to AWS Elastic Beanstalk.
@@ -14,9 +16,8 @@ import javax.validation.constraints.NotNull;
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.3
- * @goal deploy
- * @phase deploy
  */
+@Mojo(name = "deploy", defaultPhase = LifecyclePhase.DEPLOY)
 @Loggable(Loggable.INFO)
 public final class DeployMojo extends AbstractBeanstalkMojo {
 

--- a/src/main/java/com/jcabi/beanstalk/maven/plugin/Environment.java
+++ b/src/main/java/com/jcabi/beanstalk/maven/plugin/Environment.java
@@ -24,10 +24,11 @@ import com.amazonaws.services.elasticbeanstalk.model.TerminateEnvironmentResult;
 import com.amazonaws.services.elasticbeanstalk.model.UpdateEnvironmentRequest;
 import com.amazonaws.services.elasticbeanstalk.model.UpdateEnvironmentResult;
 import com.jcabi.aspects.Loggable;
-import com.jcabi.aspects.Tv;
 import com.jcabi.log.Logger;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -52,7 +53,7 @@ final class Environment {
     /**
      * For how long we can wait until env reaches certain status.
      */
-    private static final long DELAY_MS = TimeUnit.MINUTES.toMillis(Tv.THIRTY);
+    private static final long DELAY_MS = TimeUnit.MINUTES.toMillis(30L);
 
     /**
      * AWS beanstalk client.
@@ -288,7 +289,10 @@ final class Environment {
         } while (infos.isEmpty());
         final EnvironmentInfoDescription desc = infos.get(0);
         try {
-            return IOUtils.toString(new URL(desc.getMessage()).openStream());
+            return IOUtils.toString(
+                URI.create(desc.getMessage()).toURL().openStream(),
+                StandardCharsets.UTF_8
+            );
         } catch (final IOException ex) {
             throw new IllegalStateException(ex);
         }

--- a/src/main/java/com/jcabi/beanstalk/maven/plugin/UpdateMojo.java
+++ b/src/main/java/com/jcabi/beanstalk/maven/plugin/UpdateMojo.java
@@ -7,6 +7,8 @@ package com.jcabi.beanstalk.maven.plugin;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.log.Logger;
 import javax.validation.constraints.NotNull;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 
 /**
  * Update WAR artifact in AWS Elastic Beanstalk to a new version.
@@ -14,9 +16,8 @@ import javax.validation.constraints.NotNull;
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.7.1
- * @goal update
- * @phase deploy
  */
+@Mojo(name = "update", defaultPhase = LifecyclePhase.DEPLOY)
 @Loggable(Loggable.INFO)
 public final class UpdateMojo extends AbstractBeanstalkMojo {
 

--- a/src/test/java/com/jcabi/beanstalk/maven/plugin/ApplicationTest.java
+++ b/src/test/java/com/jcabi/beanstalk/maven/plugin/ApplicationTest.java
@@ -25,6 +25,7 @@ import com.jcabi.log.Logger;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -140,7 +141,7 @@ public final class ApplicationTest {
         final String name = "netbout";
         final Application app = new Application(ebt, name);
         final File war = this.temp.newFile("temp.war");
-        FileUtils.writeStringToFile(war, "broken JAR file content");
+        FileUtils.writeStringToFile(war, "broken JAR file content", StandardCharsets.UTF_8);
         final Environment candidate = app.candidate(
             new OverridingVersion(
                 ebt,

--- a/src/test/java/com/jcabi/beanstalk/maven/plugin/DeployMojoTest.java
+++ b/src/test/java/com/jcabi/beanstalk/maven/plugin/DeployMojoTest.java
@@ -4,6 +4,9 @@
  */
 package com.jcabi.beanstalk.maven.plugin;
 
+import org.apache.maven.plugins.annotations.Mojo;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
@@ -22,5 +25,19 @@ public final class DeployMojoTest {
         final DeployMojo mojo = new DeployMojo();
         mojo.setSkip(true);
         mojo.execute();
+    }
+
+    /**
+     * DeployMojo must carry a native Maven @Mojo annotation so that the
+     * plugin descriptor can be generated without the jfrog APT extractor,
+     * which relied on com.sun.mirror.apt removed in Java 8.
+     */
+    @Test
+    public void declaresGoalWithModernAnnotation() {
+        MatcherAssert.assertThat(
+            "DeployMojo must be annotated with @Mojo, not Javadoc @goal",
+            DeployMojo.class.isAnnotationPresent(Mojo.class),
+            Matchers.is(true)
+        );
     }
 }

--- a/src/test/java/com/jcabi/beanstalk/maven/plugin/DeployMojoTest.java
+++ b/src/test/java/com/jcabi/beanstalk/maven/plugin/DeployMojoTest.java
@@ -4,7 +4,10 @@
  */
 package com.jcabi.beanstalk.maven.plugin;
 
-import org.apache.maven.plugins.annotations.Mojo;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -28,16 +31,24 @@ public final class DeployMojoTest {
     }
 
     /**
-     * DeployMojo must carry a native Maven @Mojo annotation so that the
-     * plugin descriptor can be generated without the jfrog APT extractor,
-     * which relied on com.sun.mirror.apt removed in Java 8.
+     * DeployMojo class file must carry the native @Mojo annotation in its
+     * constant pool, proving the jfrog APT extractor (which required
+     * com.sun.mirror.apt removed in Java 8) is no longer used to declare
+     * the plugin goal.
+     * @throws IOException If the class file cannot be read
      */
     @Test
-    public void declaresGoalWithModernAnnotation() {
+    public void classFileMentionsMojoAnnotation() throws IOException {
+        final String path = "com/jcabi/beanstalk/maven/plugin/DeployMojo.class";
+        final InputStream stream = Thread.currentThread()
+            .getContextClassLoader().getResourceAsStream(path);
+        final String bytecode = IOUtils.toString(stream, StandardCharsets.ISO_8859_1);
         MatcherAssert.assertThat(
-            "DeployMojo must be annotated with @Mojo, not Javadoc @goal",
-            DeployMojo.class.isAnnotationPresent(Mojo.class),
-            Matchers.is(true)
+            "DeployMojo.class must reference native @Mojo, not Javadoc @goal",
+            bytecode,
+            Matchers.containsString(
+                "Lorg/apache/maven/plugins/annotations/Mojo;"
+            )
         );
     }
 }

--- a/src/test/java/com/jcabi/beanstalk/maven/plugin/OverridingBundleTest.java
+++ b/src/test/java/com/jcabi/beanstalk/maven/plugin/OverridingBundleTest.java
@@ -9,6 +9,7 @@ import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.PutObjectResult;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -40,7 +41,7 @@ public final class OverridingBundleTest {
         final String bucket = "some-bucket";
         final String key = "some-key";
         final File war = this.temp.newFile("temp.war");
-        FileUtils.writeStringToFile(war, "broken JAR file content");
+        FileUtils.writeStringToFile(war, "broken JAR file content", StandardCharsets.UTF_8);
         final AmazonS3 client = Mockito.mock(AmazonS3.class);
         Mockito.doReturn(new PutObjectResult())
             .when(client).putObject(bucket, key, war);
@@ -65,7 +66,7 @@ public final class OverridingBundleTest {
     public void cachesResultOfLocation() throws Exception {
         final AmazonS3 client = Mockito.mock(AmazonS3.class);
         final File war = this.temp.newFile("temp1.war");
-        FileUtils.writeStringToFile(war, "some JAR file content");
+        FileUtils.writeStringToFile(war, "some JAR file content", StandardCharsets.UTF_8);
         final String bucket = "some-bucket-for-cache";
         final String key = "some-key-for-cache";
         Mockito.doReturn(new PutObjectResult())


### PR DESCRIPTION
Fixes #17.

The root cause was that DeployMojo and UpdateMojo used old Javadoc-style mojo descriptor tags (@goal, @phase, @parameter) instead of Java annotations. Under Java 8, maven-plugin-plugin attempted to invoke the jfrog APT extractor to parse those Javadoc tags. That extractor depends on com.sun.mirror.apt.AnnotationProcessorFactory, which Sun removed entirely from Java 8, causing the build to crash with a NoClassDefFoundError.

The fix replaces all Javadoc mojo tags with @Mojo and @Parameter annotations from org.apache.maven.plugin-tools:maven-plugin-annotations, which the java-annotations extractor in maven-plugin-plugin picks up without any APT dependency. Along with that, maven-plugin-plugin is upgraded to 3.10.2 (the 3.2 version in the parent POM carries an ASM version that cannot read modern JVM class files), the compiler source and target are set to 1.8 in the project POM (the parent fixes them at 1.6, which modern javac refuses), Lombok is updated to 1.18.30, Mockito is updated to 4.11.0, AspectJ weaving is switched to aspectj-maven-plugin 1.14.0 with AspectJ 1.9.7 (the version bundled in the old jcabi-maven-plugin cannot read Java 9+ constant pool entries and silently skips weaving), and jcabi-maven-slf4j is scoped as provided so the test classpath picks up the log4j SLF4J binding instead of the Maven-log bridge that requires an active MojoLog during tests.

All 22 unit tests pass after the change.